### PR TITLE
Fix EthereumAddress operator null handling

### DIFF
--- a/src/Net.Web3.EthereumWallet/EthereumAddress.cs
+++ b/src/Net.Web3.EthereumWallet/EthereumAddress.cs
@@ -136,8 +136,10 @@ namespace Net.Web3.EthereumWallet
         /// <param name="left">The first EthereumAddress instance.</param>
         /// <param name="right">The second EthereumAddress instance.</param>
         /// <returns>true if the instances are equal; otherwise, false.</returns>
-        public static bool operator ==(EthereumAddress left, EthereumAddress right)
+        public static bool operator ==(EthereumAddress? left, EthereumAddress? right)
         {
+            if (ReferenceEquals(left, right)) return true;
+            if (left is null || right is null) return false;
             return left.Equals(right);
         }
 
@@ -147,9 +149,9 @@ namespace Net.Web3.EthereumWallet
         /// <param name="left">The first EthereumAddress instance.</param>
         /// <param name="right">The second EthereumAddress instance.</param>
         /// <returns>true if the instances are not equal; otherwise, false.</returns>
-        public static bool operator !=(EthereumAddress left, EthereumAddress right)
+        public static bool operator !=(EthereumAddress? left, EthereumAddress? right)
         {
-            return !left.Equals(right);
+            return !(left == right);
         }
         #endregion
     }

--- a/tests/Net.Web3.EthereumWallet.Tests/EthereumAddressTests.cs
+++ b/tests/Net.Web3.EthereumWallet.Tests/EthereumAddressTests.cs
@@ -214,8 +214,9 @@ public class EthereumAddressTests
     internal void ComparisonOperators_AddressEqualsNull()
     {
         var address1 = new EthereumAddress(ZeroAddress);
+        EthereumAddress? address2 = null;
 
-        var result = address1 == null;
+        var result = address1 == address2;
 
         result.Should().BeFalse();
     }

--- a/tests/Net.Web3.EthereumWallet.Tests/EthereumAddressTests.cs
+++ b/tests/Net.Web3.EthereumWallet.Tests/EthereumAddressTests.cs
@@ -198,4 +198,36 @@ public class EthereumAddressTests
 
         result.Should().BeFalse();
     }
+
+    [Fact]
+    internal void ComparisonOperators_NullEqualsNull()
+    {
+        EthereumAddress? address1 = null;
+        EthereumAddress? address2 = null;
+
+        var result = address1 == address2;
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    internal void ComparisonOperators_AddressEqualsNull()
+    {
+        var address1 = new EthereumAddress(ZeroAddress);
+
+        var result = address1 == null;
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    internal void ComparisonOperators_NullNotEqualsAddress()
+    {
+        EthereumAddress? address1 = null;
+        var address2 = new EthereumAddress(ZeroAddress);
+
+        var result = address1 != address2;
+
+        result.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Summary
- handle nulls in EthereumAddress equality operators
- add unit tests for null comparisons

## Testing
- `dotnet build Net.Web3.EthereumWallet.sln --no-restore` *(fails: assets file not found)*
- `dotnet test Net.Web3.EthereumWallet.sln --no-restore --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_6863b246ca50832ab0d319977b9c3ecf